### PR TITLE
Refactor :  works fetching logic into module

### DIFF
--- a/FrontEnd/assets/script/main.js
+++ b/FrontEnd/assets/script/main.js
@@ -1,42 +1,4 @@
-/**
- * Fetches the list of works from the API.
- * @async
- * @function getWorks
- * @returns {Promise<Array<Object>>} A promise that resolves to an array of work objects.
- */
-async function getWorks() {
-    const responseWorks = await fetch('http://127.0.0.1:5678/api/works');
-    const dataWorks = await responseWorks.json();
-    console.log(dataWorks);
-    return dataWorks;
-}
-
-
-/**
- * Displays the provided works in the gallery section of the DOM.
- * @function displayWorks
- * @param {Array<Object>} workLocation - Array of work objects to display.
- * @returns {void}
- */
-function displayWorks(workLocation) {
-    const divGallery = document.querySelector(".gallery");
-    divGallery.innerHTML = "";
-    workLocation.forEach(work => {
-        const figure = document.createElement('figure');
-
-        const img = document.createElement('img');
-        img.src = work.imageUrl;
-        img.alt = work.title;
-
-        const figcaption = document.createElement('figcaption');
-        figcaption.textContent = work.title;
-
-        figure.appendChild(img);
-        figure.appendChild(figcaption);
-        divGallery.appendChild(figure);
-    });
-
-}
+import  {worksInit} from "./modules/getWorks.js";
 
 
 /**
@@ -46,8 +8,7 @@ function displayWorks(workLocation) {
  * @returns {Promise<void>}
  */
 async function init() {
-    const dataWorks = await getWorks();
-    displayWorks(dataWorks);
+    worksInit()
 }
 
 

--- a/FrontEnd/assets/script/modules/getWorks.js
+++ b/FrontEnd/assets/script/modules/getWorks.js
@@ -1,0 +1,44 @@
+/**
+ * Fetches the list of works from the API.
+ * @async
+ * @function getWorks
+ * @returns {Promise<Array<Object>>} A promise that resolves to an array of work objects.
+ */
+async function getWorks() {
+    const responseWorks = await fetch('http://127.0.0.1:5678/api/works');
+    const dataWorks = await responseWorks.json();
+    console.log(dataWorks);
+    return dataWorks;
+}
+
+
+/**
+ * Displays the provided works in the gallery section of the DOM.
+ * @function displayWorks
+ * @param {Array<Object>} workLocation - Array of work objects to display.
+ * @returns {void}
+ */
+function displayWorks(workLocation) {
+    const divGallery = document.querySelector(".gallery");
+    divGallery.innerHTML = "";
+    workLocation.forEach(work => {
+        const figure = document.createElement('figure');
+
+        const img = document.createElement('img');
+        img.src = work.imageUrl;
+        img.alt = work.title;
+
+        const figcaption = document.createElement('figcaption');
+        figcaption.textContent = work.title;
+
+        figure.appendChild(img);
+        figure.appendChild(figcaption);
+        divGallery.appendChild(figure);
+    });
+
+}
+
+export async function worksInit(){
+    const dataWorks = await getWorks();
+    displayWorks(dataWorks);
+}


### PR DESCRIPTION
Moved the getWorks and displayWorks functions from main.js to a new getWorks.js module. Updated main.js to use the new worksInit function for initializing and displaying works, improving code organization and modularity.