### PR TITLE
fix : Update import to use getWorksInit function

### DIFF
--- a/FrontEnd/assets/script/main.js
+++ b/FrontEnd/assets/script/main.js
@@ -1,4 +1,4 @@
-import  {worksInit} from "./modules/getWorks.js";
+import  {getWorksInit} from "./modules/getWorks.js";
 
 
 /**


### PR DESCRIPTION
Renamed the imported function from worksInit to getWorksInit in main.js to match the updated export from getWorks.js.