### PR TITLE
Refactor getWorksInit to accept parameters

### DIFF
--- a/FrontEnd/assets/script/main.js
+++ b/FrontEnd/assets/script/main.js
@@ -8,7 +8,7 @@ import  {getWorksInit} from "./modules/getWorks.js";
  * @returns {Promise<void>}
  */
 async function init() {
-    getWorksInit()
+    getWorksInit('works', '.gallery')
 }
 
 

--- a/FrontEnd/assets/script/modules/getWorks.js
+++ b/FrontEnd/assets/script/modules/getWorks.js
@@ -9,9 +9,9 @@ import { getFrom } from "./fetcher.js";
  * @function worksInit
  * @returns {Promise<void>} Resolves when works have been fetched and displayed.
  */
-export async function getWorksInit() {
-    const fetchedWorks = await getFrom('works');
-    displayWorks(fetchedWorks, '.gallery');
+export async function getWorksInit(endpoint, elementId) {
+    const fetchedWorks = await getFrom(endpoint);
+    displayWorks(fetchedWorks, elementId);
 }
 
 


### PR DESCRIPTION
Updated getWorksInit to take endpoint and element selector as arguments for improved flexibility. Adjusted main.js to pass the required parameters when initializing.